### PR TITLE
Add keldoc.com password restrictions

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -332,6 +332,9 @@
     "japanpost.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
+    "keldoc.com": {
+        "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!@#$%^&*];"
+    },
     "key.harvard.edu": {
         "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^[']];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Safari's autofill fails for [this French website](https://www.keldoc.com) because of the special characters requirement:

![Proof](https://user-images.githubusercontent.com/7999977/118006506-99d93480-b34b-11eb-95f2-3a050ef2535e.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
